### PR TITLE
Messaging Module: Add Support for PDF Template Demo to Production Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,12 @@
 FROM node:18.17.0-alpine3.17
 
+# See https://pptr.dev/chromium-support for supported chrome to puppeteer version.
+RUN apk add --no-cache \
+        chromium=112.0.5615.165-r0
+
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
+    PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
+
 RUN mkdir /home/node/app && chown -R node:node /home/node/app
 RUN mkdir /home/node/web && chown -R node:node /home/node/web
 

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ You can boot the production environment locally via:
 6. Booting the production build of the app.
 
    ```bash
-   docker compose up --build --remove-orphans
+   docker compose up --build
    ```
 
    > Note that you must always boot the production app after booting the database.

--- a/README.md
+++ b/README.md
@@ -199,14 +199,15 @@ Steps:
 
 ---
 
-## Running the application in production
+## Deployment
+
+### Production
 
 Since the database for this system is managed externally, PRODUCTION version only needs to run the API and Web services.
-The `Dockerfile` in this directory builds the Vue.js web front-end, and serves the compiled files via the Node.js API,
-so only one container is required to serve the front-end and back-ends; thus saving resources.
 
-On the PRODUCTION server, the application is run via docker-compose, so the code needs to be cloned to the server and
-the appropriate environment variables set using the following commands:
+The [Dockerfile](./Dockerfile) in this directory builds the Vue.js web front-end, and serves the compiled files via the Node.js API, so only one container is required to serve the front-end and back-ends; thus saving resources.
+
+On the PRODUCTION server, the application is run via `docker compose`, so the code needs to be cloned to the server and the appropriate environment variables set using the following commands:
 
 ```
 cp /src/api/.env /src/api/.env.production
@@ -216,13 +217,17 @@ vi /src/api/.env.production
 You now can use vi or nano or other tool to set the environment variables before starting the application with:
 
 ```
-docker-compose -f docker-compose.production.yml up --build -d
+docker compose up --build -d
 ```
 
 When you look at the running Docker containers using `docker ps`, you should see a container named `sfa-client_web_1`.
 
 ```
 
-**One thing to keep in mind is that the port in the `docker-compose.prodution.yml` may need to be changed
-depending the the reverse proxy setups.**
+**One thing to keep in mind is that the port in the `docker-compose.prodution.yml` may need to be changed depending the the reverse proxy setups.**
 ```
+
+### User Acceptance Testing (UAT)
+
+Jenkins pipeline [Jenkinsfile](./Jenkinsfile) builds and deploys.
+TODO: add more information

--- a/README.md
+++ b/README.md
@@ -227,6 +227,39 @@ When you look at the running Docker containers using `docker ps`, you should see
 **One thing to keep in mind is that the port in the `docker-compose.prodution.yml` may need to be changed depending the the reverse proxy setups.**
 ```
 
+#### Testing Production Buid Locally
+
+You can boot the production environment locally via:
+
+1. Making a production config.
+
+   ```bash
+   cp ./src/api/.env.development ./src/api/.env.production
+   ```
+
+2. Setting the `DB_HOST` to `db`
+
+3. Setting the `FRONTEND_URL` to `http://localhost:3000`
+
+4. Setting the `AUTH_REDIRECT` to `http://localhost:3000/dashboard`
+
+5. Booting the development database.
+
+   ```bash
+   dev db
+
+   # Or
+   docker compose -f docker-compose.development.yaml up --remove-orphans db
+   ```
+
+6. Booting the production build of the app.
+
+   ```bash
+   docker compose up --build --remove-orphans
+   ```
+
+   > Note that you must always boot the production app after booting the database.
+
 ### User Acceptance Testing (UAT)
 
 Jenkins pipeline [Jenkinsfile](./Jenkinsfile) builds and deploys.

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ When you look at the running Docker containers using `docker ps`, you should see
 **One thing to keep in mind is that the port in the `docker-compose.prodution.yml` may need to be changed depending the the reverse proxy setups.**
 ```
 
-#### Testing Production Buid Locally
+#### Testing Production Build Locally
 
 You can boot the production environment locally via:
 


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/sfa-client/issues/5

# Context

My original PDF template demo was only enable for development. See https://github.com/icefoganalytics/sfa-client/issues/1

Update production deploy to include new PDF generation code.

# Testing Instructions

Test the production build locally by:

1. Making a production config.

   ```bash
   cp ./src/api/.env.development ./src/api/.env.production
   ```

2. Setting the `DB_HOST` to `db`

3. Setting the `FRONTEND_URL` to `http://localhost:3000`

4. Setting the `AUTH_REDIRECT` to `http://localhost:3000/dashboard`

5. Booting the development database.

   ```bash
   dev db

   # Or
   docker compose -f docker-compose.development.yaml up --remove-orphans db
   ```

6. Booting the production build of the app.

   ```bash
   docker compose up --build
   ```

   > Note that you must always boot the production app after booting the database.
