### PR TITLE
Config Fixups To Support Running `student-financial-aid` Alongside the `sfa-client`

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,10 @@ e.g
 - `dev build api` will only build the api service
 - `dev logs api` will only watch logs for the api service
 
+### Helpful Customizations
+
+- `API_PORT=3100 dev up` will boot the api service on port 3100 with a base url to match.
+
 ## Contributing code
 
 To process to contribute code to this repository is via pull requests initiated from a forked copy of this repository.

--- a/docker-compose.development.yaml
+++ b/docker-compose.development.yaml
@@ -10,8 +10,10 @@ services:
     environment:
       NODE_ENV: development
       DB_HOST: db
+      API_PORT: ${API_PORT:-3000}
+      BASE_URL: "http://localhost:${API_PORT:-3000}"
     ports:
-      - "3000:3000"
+      - "${API_PORT:-3000}:${API_PORT:-3000}"
     volumes:
       - ./src/api:/usr/src/api
     depends_on:


### PR DESCRIPTION
Relates to:
- https://github.com/icefoganalytics/student-financial-aid/issues/3

Fixes https://github.com/icefoganalytics/sfa-client/issues/8

# Context

`sfa-client` needs to run the database service, and the api service on port 3100 with a base url on the correct 3100 port as well.

# Implementation

Update docker compose development config to support custom api port.

Usage: `API_PORT=3100 dev up` sets the api port and base url port