### PR TITLE
Enhancement: Specify Default Schema At Config Level

### DIFF
--- a/docker-compose.development.yaml
+++ b/docker-compose.development.yaml
@@ -10,6 +10,7 @@ services:
     environment:
       NODE_ENV: development
       DB_HOST: db
+      DB_DEFAULT_SCHEMA: sfa
       API_PORT: ${API_PORT:-3000}
       BASE_URL: "http://localhost:${API_PORT:-3000}"
     ports:

--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -26,6 +26,7 @@ export const DB_USER = process.env.DB_USER || "";
 export const DB_PASS = process.env.DB_PASS || "";
 export const DB_HOST = process.env.DB_HOST || "";
 export const DB_PORT = process.env.DB_PORT || "";
+export const DB_DEFAULT_SCHEMA = process.env.DB_DEFAULT_SCHEMA;
 
 export const BASE_URL = process.env.BASE_URL || "";
 export const CLIENT_ID = process.env.CLIENT_ID || "";
@@ -41,6 +42,7 @@ export const DB_CONFIG = {
     database: DB_NAME,
     port: parseInt(DB_PORT),
   },
+  defaultSchema: DB_DEFAULT_SCHEMA || 'dbo',
 };
 
 export const MAIL_FROM = process.env.MAIL_FROM || "sfa@yukon.ca";

--- a/src/api/db/db-client.ts
+++ b/src/api/db/db-client.ts
@@ -25,7 +25,11 @@ const dbWithSchema: Knex = new Proxy(db, {
   },
   get: (target, prop: keyof Knex) => {
     if (typeof target[prop] === "function") {
-      return (...args: any[]) => target[prop](...args).withSchema(DB_CONFIG.defaultSchema)
+      if (prop === "withSchema") {
+        return (schema: string) => target[prop](schema) // format taken from src/api/node_modules/knex/types/index.d.ts
+      } else {
+        return (...args: any[]) => target[prop](...args).withSchema(DB_CONFIG.defaultSchema)
+      }
     }
     return target[prop]
   },

--- a/src/api/db/db-client.ts
+++ b/src/api/db/db-client.ts
@@ -1,11 +1,12 @@
-import knex from "knex"
+import knex, { Knex } from "knex"
 import camelcaseKeys from "camelcase-keys"
 import { snakeCase } from "lodash"
 
 import { DB_CONFIG } from "@/config"
 
 const db = knex({
-  ...DB_CONFIG,
+  client: DB_CONFIG.client,
+  connection: DB_CONFIG.connection,
   postProcessResponse: (result, queryContext) => {
     if (Array.isArray(result)) {
       // For SELECT queries
@@ -18,4 +19,16 @@ const db = knex({
   wrapIdentifier: (value, origImpl, queryContext) => origImpl(snakeCase(value)),
 })
 
-export default db
+const dbWithSchema: Knex = new Proxy(db, {
+  apply: (target, thisArg, argumentsList) => {
+    return target(...argumentsList).withSchema(DB_CONFIG.defaultSchema)
+  },
+  get: (target, prop: keyof Knex) => {
+    if (typeof target[prop] === "function") {
+      return (...args: any[]) => target[prop](...args).withSchema(DB_CONFIG.defaultSchema)
+    }
+    return target[prop]
+  },
+})
+
+export default dbWithSchema

--- a/src/api/services/admin/application-letter-service.ts
+++ b/src/api/services/admin/application-letter-service.ts
@@ -94,17 +94,17 @@ export default class ApplicationLetterService {
   async #getApplicationData(): Promise<any> {
     if (this.#applicationData) return this.#applicationData
 
-    const application = await db("sfa.application").where({ id: this.#applicationId }).first()
+    const application = await db("application").where({ id: this.#applicationId }).first()
     if (!application) {
       return Promise.reject(new Error("Application not found"))
     }
 
-    const student = await db("sfa.student").where({ id: application.studentId }).first()
+    const student = await db("student").where({ id: application.studentId }).first()
     if (!student) {
       return Promise.reject(new Error("Student not found"))
     }
 
-    const person = await db("sfa.person").where({ id: student.personId }).first()
+    const person = await db("person").where({ id: student.personId }).first()
     if (!person) {
       return Promise.reject(new Error("Person not found"))
     }


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/sfa-client/issues/20

# Context

Currently we are specifying the default schema on a per-request basis and this is a pain.
The interface should work such that:
a) `db('user').limit(10)` produces `select sfa.user limit 10`
b) `db.from('user').limit(10)` produces `select sfa.user limit 10`
c) `db.withSchema('dbo').from('user').limit(10)` produces `select dbo.user limit 10`

# Solution

:tada: Add support for default schema in DB_CONFIG set by ENV variable.
See https://github.com/icefoganalytics/sfa-client/pull/13/commits/6931e1fc19bdb867ef2e180c3faee99e1f6aa602 for example of the kind of improvement this leads too.

# Testing Instructions

1. Boot the app.
2. Log in to the app.
3. Check that db-client queries work without a schema specified by going to http://localhost:3000/api/v2/admin/application-letter/250/approval/yukon-grant-student.html
4. Perform any additional manual testing via `dev npm exec ts-node`
e.g.
```
import db from './db/db-client'
db.select('id').from('user').then(console.log)

db('user').limit(10).toString()
db.from('user').limit(10).toString()
db('user').withSchema('dbo').limit(10).toString()
db.withSchema('dbo').from('user').limit(10).toString()
```