### PR TITLE
Enhancement: Add Education Section to Student Application Endpoint Response

### DIFF
--- a/docker-compose.development.yaml
+++ b/docker-compose.development.yaml
@@ -37,7 +37,7 @@ services:
       <<: *environment-definition
       NODE_ENV: test
       DB_NAME: sfa_client_test
-      DB_DEFAULT_SCHEMA: dbo
+      DB_DEFAULT_SCHEMA: sfa
     tty: true
     volumes:
       - ./src/api:/usr/src/api

--- a/src/api/routes/portal/index.ts
+++ b/src/api/routes/portal/index.ts
@@ -1,22 +1,22 @@
-import express, { Request, Response } from "express";
+import express, { Request, Response } from "express"
 
-import { portalApplicationRouter } from "./application-router";
-import { portalReferenceRouter } from "./reference-router";
-import { portalStudentRouter } from "./student-router";
+import { portalApplicationRouter } from "./application-router"
+import { portalReferenceRouter } from "./reference-router"
+import { portalStudentRouter } from "./student-router"
 
-import { routedTo } from '@/controllers/helpers'
+import { routedTo } from "@/controllers/helpers"
 import StudentApplicationsController from "@/controllers/portal/students/student-applications-controller"
 import StudentApplicationDraftsController from "@/controllers/portal/students/student-application-drafts-controller"
 
-export const portalRouter = express.Router();
+export const portalRouter = express.Router()
 
-portalRouter.use("/student", portalStudentRouter);
-portalRouter.use("/application", portalApplicationRouter);
-portalRouter.use("/reference", portalReferenceRouter);
+portalRouter.use("/student", portalStudentRouter)
+portalRouter.use("/application", portalApplicationRouter)
+portalRouter.use("/reference", portalReferenceRouter)
 
 portalRouter.get("/", (req: Request, res: Response) => {
-  res.send("portalRouterIndex");
-});
+  res.send("portalRouterIndex")
+})
 
 portalRouter.get(
   "/students/:studentId/applications",
@@ -32,5 +32,5 @@ portalRouter.get(
 )
 portalRouter.get(
   "/students/:studentId/application-drafts/:applicationDraftId",
-  routedTo(StudentApplicationDraftsController, 'getStudentApplicationDraft')
+  routedTo(StudentApplicationDraftsController, "getStudentApplicationDraft")
 )

--- a/src/api/routes/portal/index.ts
+++ b/src/api/routes/portal/index.ts
@@ -31,6 +31,6 @@ portalRouter.get(
   routedTo(StudentApplicationDraftsController, "listStudentApplicationDrafts")
 )
 portalRouter.get(
-  "/students/:studentId/draft-applications/:applicationDraftId",
+  "/students/:studentId/application-drafts/:applicationDraftId",
   routedTo(StudentApplicationDraftsController, 'getStudentApplicationDraft')
 )

--- a/src/api/serializers/application-drafts-serializer.ts
+++ b/src/api/serializers/application-drafts-serializer.ts
@@ -1,36 +1,66 @@
-import { isArray, pick } from "lodash"
+import { isArray } from "lodash"
 
+import Application from "@/models/application"
 import ApplicationDraft from "@/models/application-draft"
 
 export default class ApplicationsSerializer {
   #applicationDrafts: ApplicationDraft[] = []
-  #applicationDraft: ApplicationDraft | {} = {}
+  #applicationDraft: ApplicationDraft = {} as ApplicationDraft
 
   constructor(draftOrDrafts: ApplicationDraft[] | ApplicationDraft) {
     if (isArray(draftOrDrafts)) {
-      this.#applicationDrafts = draftOrDrafts || []
+      this.#applicationDrafts = draftOrDrafts || ([] as ApplicationDraft[])
     } else {
-      this.#applicationDraft = draftOrDrafts || {}
+      this.#applicationDraft = draftOrDrafts || ({} as ApplicationDraft)
     }
   }
 
   asListView() {
     return this.#applicationDrafts.map((applicationDraft) => {
-      return pick(applicationDraft, [
-        "id",
-        "studentId",
-        "academicYearId",
-        "createDate",
-        "updateDate",
-        "isActive",
-        "submitDate",
-        "status",
-        "description",
-      ])
+      return {
+        id: applicationDraft.id,
+        studentId: applicationDraft.studentId,
+        academicYearId: applicationDraft.academicYearId,
+        createDate: applicationDraft.createDate,
+        updateDate: applicationDraft.updateDate,
+        isActive: applicationDraft.isActive,
+        submitDate: applicationDraft.submitDate,
+        status: applicationDraft.status,
+        description: "TODO", // Does not exist on model
+      }
     })
   }
 
   asDetailedView() {
-    return this.#applicationDraft
+    const application = this.#parseApplicationJson(this.#applicationDraft.applicationJson)
+    return {
+      id: this.#applicationDraft.id,
+      studentId: this.#applicationDraft.studentId,
+      academicYearId: this.#applicationDraft.academicYearId,
+      createDate: this.#applicationDraft.createDate,
+      updateDate: this.#applicationDraft.updateDate,
+      isActive: this.#applicationDraft.isActive,
+      submitDate: this.#applicationDraft.submitDate,
+      status: this.#applicationDraft.status,
+      description: "TODO", // Does not exist on model
+      application: this.#applicationAssocation(application),
+    }
+  }
+
+  #parseApplicationJson(applicationJson: string): Application {
+    try {
+      return JSON.parse(applicationJson)
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new Error(`Could not parse application JSON: ${error.message}`)
+      } else {
+        throw new Error(`Could not parse application JSON`)
+      }
+    }
+  }
+
+  #applicationAssocation(application: Application) {
+    // Makes space for future filtering or mutations
+    return application
   }
 }

--- a/src/api/serializers/application-drafts-serializer.ts
+++ b/src/api/serializers/application-drafts-serializer.ts
@@ -3,7 +3,7 @@ import { isArray } from "lodash"
 import Application from "@/models/application"
 import ApplicationDraft from "@/models/application-draft"
 
-export default class ApplicationsSerializer {
+export default class ApplicationDraftsSerializer {
   #applicationDrafts: ApplicationDraft[] = []
   #applicationDraft: ApplicationDraft = {} as ApplicationDraft
 

--- a/src/api/serializers/application-drafts-serializer.ts
+++ b/src/api/serializers/application-drafts-serializer.ts
@@ -1,4 +1,5 @@
 import { isArray } from "lodash"
+import camelcaseKeys from "camelcase-keys"
 
 import Application from "@/models/application"
 import ApplicationDraft from "@/models/application-draft"
@@ -60,7 +61,6 @@ export default class ApplicationDraftsSerializer {
   }
 
   #applicationAssocation(application: Application) {
-    // Makes space for future filtering or mutations
-    return application
+    return camelcaseKeys(application, { deep: true })
   }
 }

--- a/src/api/serializers/applications-serializer.ts
+++ b/src/api/serializers/applications-serializer.ts
@@ -1,4 +1,4 @@
-import { compact, isArray, isEmpty, last, sortBy, sumBy, uniq } from "lodash"
+import { compact, isArray, isEmpty, isNil, last, sortBy, sumBy, uniq } from "lodash"
 
 import { NON_EXISTANT_ID } from "@/utils/constants"
 
@@ -79,8 +79,7 @@ export default class ApplicationsSerializer {
         this.#application,
         this.#application.student?.residences || ([] as Residence[])
       ),
-      education: this.#educationAssociation(),
-      // TODO: investigate if I need a "parents" field
+      education: this.#educationAssociation(this.#application.student || ({} as Student)),
     }
   }
 
@@ -259,10 +258,25 @@ export default class ApplicationsSerializer {
     }
   }
 
-  #educationAssociation() {
-    // TODO: replace with real data
+  // FUTURE: this will probably pull from the education table at some point?
+  #educationAssociation(student: Student) {
+    const educationHistory = []
+
+    if (
+      !isNil(student.highSchoolId) &&
+      !isNil(student.highSchoolLeftYear) &&
+      !isNil(student.highSchoolLeftMonth)
+    ) {
+      educationHistory.push({
+        leftHighSchool: `${student.highSchoolLeftYear}/${student.highSchoolLeftMonth}`,
+        school: student.highSchoolId,
+      })
+    } else {
+      educationHistory.push({})
+    }
+
     return {
-      educationHistory: [{ leftHighSchool: "2023/02", school: 310 }],
+      educationHistory,
     }
   }
 }

--- a/src/api/services/portal/students/student-application-drafts-service.ts
+++ b/src/api/services/portal/students/student-application-drafts-service.ts
@@ -26,5 +26,6 @@ export default class StudentApplicationsService {
 
     return db("applicationDraft")
       .where({ id: this.#applicationDraftId, studentId: this.#studentId })
+      .first()
   }
 }

--- a/src/api/services/portal/students/student-application-drafts-service.ts
+++ b/src/api/services/portal/students/student-application-drafts-service.ts
@@ -1,6 +1,6 @@
 import db from "@/db/db-client"
 
-export default class StudentApplicationsService {
+export default class StudentApplicationDraftsService {
   #studentId: number
   #applicationDraftId?: number
 

--- a/src/api/services/portal/students/student-application-drafts-service.ts
+++ b/src/api/services/portal/students/student-application-drafts-service.ts
@@ -4,13 +4,19 @@ export default class StudentApplicationsService {
   #studentId: number
   #applicationDraftId?: number
 
-  constructor({ studentId, applicationDraftId }: { studentId: number; applicationDraftId?: number }) {
+  constructor({
+    studentId,
+    applicationDraftId,
+  }: {
+    studentId: number
+    applicationDraftId?: number
+  }) {
     this.#studentId = studentId
     this.#applicationDraftId = applicationDraftId
   }
 
   getApplicationDrafts() {
-    return db("application_draft").where({ student_id: this.#studentId })
+    return db("applicationDraft").where({ studentId: this.#studentId })
   }
 
   getApplicationDraft() {
@@ -18,6 +24,7 @@ export default class StudentApplicationsService {
       throw new Error("Application Draft ID is not set")
     }
 
-    return db("application_draft").where({ id: this.#applicationDraftId, student_id: this.#studentId })
+    return db("applicationDraft")
+      .where({ id: this.#applicationDraftId, studentId: this.#studentId })
   }
 }

--- a/src/api/services/portal/students/student-application-students-service.ts
+++ b/src/api/services/portal/students/student-application-students-service.ts
@@ -16,6 +16,9 @@ export default class StudentApplicationStudentsService {
     return db
       .select({
         t1Id: "student.id",
+        t1HighSchoolId: "highSchoolId",
+        t1HighSchoolLeftYear: "highSchoolLeftYear",
+        t1HighSchoolLeftMonth: "highSchoolLeftMonth",
         t2Id: "person.id",
         t2FirstName: "person.firstName",
         t2LastName: "person.lastName",
@@ -38,6 +41,9 @@ export default class StudentApplicationStudentsService {
       .then((result) => {
         return {
           id: result.t1Id,
+          highSchoolId: result.t1HighSchoolId,
+          highSchoolLeftYear: result.t1HighSchoolLeftYear,
+          highSchoolLeftMonth: result.t1HighSchoolLeftMonth,
           personId: result.t2Id,
           person: {
             id: result.t2Id,

--- a/src/api/services/portal/students/student-applications-service.ts
+++ b/src/api/services/portal/students/student-applications-service.ts
@@ -27,6 +27,10 @@ export default class StudentApplicationsService {
       .where({ id: this.#applicationId, studentId: this.#studentId })
       .first()
 
+    if (application === undefined) {
+      throw new Error(`Application not found for id=${this.#applicationId} and studentId=${this.#studentId}`)
+    }
+
     if (application.institutionCampusId) {
       application.institution = await db("institution")
         .where({ id: application.institutionCampusId })


### PR DESCRIPTION
Relates to https://github.com/icefoganalytics/student-financial-aid/issues/2
Fixes https://github.com/icefoganalytics/sfa-client/issues/24

# Context

As part of the "view submitted applications and their current status" project, this task covers returning the education data. 

Also performed some fixups to the `/api/portal/students/:studentId/application-drafts` endpoint and services.

# Data Format

```json
{
  "id": "some-application-id",
  "education": {
     "educationHistory": [{ "leftHighSchool": "2023/02", "school": 310 }]
   },
}
```

# Testing Instructions

1. Boot the `sfa-client` back-end via `API_PORT=3100 db up`
2. Boot the `student-financial-aid` back-end via
```
cd src/api
npm run start
```
3. Boot the `student-financial-aid` front-end via
```
cd src/web
npm run start
```
4. Log in to the app at http://localhost:8080/
5. Check for the education history in the data blob returned by `http://localhost:3000/api/portal/students/250/applications/4299`. It will be an empty blob.
6. Check for education history in http://localhost:3000/api/portal/students/1/applications/2198. It will have some school and date info.