### PR TITLE
Enhancement: Add Other Funding Section to Student Application Endpoint Response

### DIFF
--- a/src/api/db/db-client.ts
+++ b/src/api/db/db-client.ts
@@ -19,7 +19,7 @@ const db = knex({
     }
   },
   wrapIdentifier: (value, origImpl, queryContext) => {
-    if (value === '*') {
+    if (value === "*") {
       return origImpl(value)
     }
 
@@ -40,12 +40,18 @@ const dbWithSchema: Knex = new Proxy(db, {
     if (typeof target[prop] === "function") {
       if (prop === "withSchema") {
         return (schema: string) => target[prop](schema) // format taken from src/api/node_modules/knex/types/index.d.ts
-      } else if (prop === "destroy") {
-        return (callback: Function) => db.destroy(callback)
-      } else {
-        return (...args: any[]) => target[prop](...args).withSchema(DB_CONFIG.defaultSchema)
+      }
+
+      return (...args: any[]) => {
+        const result = target[prop](...args)
+        if (typeof result === "object" && typeof result["withSchema"] === "function") {
+          return result.withSchema(DB_CONFIG.defaultSchema)
+        }
+
+        return result
       }
     }
+
     return target[prop]
   },
 })

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -12,7 +12,7 @@ import { doHealthCheck } from "./utils/health_check";
 import { RequireActive, configureAuthentication } from "./routes/auth";
 
 import * as Sentry from "@sentry/node";
-import { CreateMigrationRoutes, migrateLatest } from "./data/migrator";
+import { CreateMigrationRoutes } from "./data/migrator";
 if (config.SENTRY_DSN.length > 0) Sentry.init({ dsn: config.SENTRY_DSN });
 
 const app = express();

--- a/src/api/models/agency-assistance.ts
+++ b/src/api/models/agency-assistance.ts
@@ -1,0 +1,12 @@
+export default interface AgencyAssistance {
+  id: number
+  agencyId: number
+  applicationId: number
+  amount: number
+  isTuition: boolean
+  isLivingExpenses: boolean
+  isBooks: boolean
+  isTransportation: boolean
+  otherPurpose?: string
+  agencyComment?: string
+}

--- a/src/api/models/application.ts
+++ b/src/api/models/application.ts
@@ -1,3 +1,4 @@
+import AgencyAssistance from "@/models/agency-assistance"
 import Attendance from "@/models/attendance"
 import FundingRequest from "@/models/funding-request"
 import Institution from "@/models/institution"
@@ -157,6 +158,7 @@ export default interface Application_ {
   isPersistDisabled: boolean
   persistDisabledStartDate?: Date
   isChequesToInstitution: boolean
+  agencyAssistances?: AgencyAssistance[]
   attendance?: Attendance
   fundingRequests?: FundingRequest[]
   institution?: Institution

--- a/src/api/models/funding-purpose.ts
+++ b/src/api/models/funding-purpose.ts
@@ -1,0 +1,9 @@
+enum FundingPurpose {
+  TUITION = "Tuition",
+  BOOKS = "Books",
+  LIVING_EXPENSES = "Living Expenses",
+  TRANSPORTATION = "Transportation",
+  OTHER = "Other",
+}
+
+export default FundingPurpose

--- a/src/api/services/portal/students/student-applications-service.ts
+++ b/src/api/services/portal/students/student-applications-service.ts
@@ -49,6 +49,7 @@ export default class StudentApplicationsService {
 
     application.fundingRequests = await this.#getApplicationFundingRequests(application.id)
     application.student = await this.#getApplicationStudent(application.studentId)
+    application.agencyAssistances = await this.#getApplicationAgencyAssistances(application.id)
 
     return application
   }
@@ -61,5 +62,9 @@ export default class StudentApplicationsService {
   #getApplicationStudent(studentId: number) {
     const studentService = new StudentApplicationStudentsService({ studentId })
     return studentService.getStudent()
+  }
+
+  #getApplicationAgencyAssistances(applicationId: number) {
+    return db("agencyAssistance").where({ applicationId })
   }
 }

--- a/src/api/tests/db/db-client.test.ts
+++ b/src/api/tests/db/db-client.test.ts
@@ -1,9 +1,44 @@
-import db from '@/db/db-client';
+import db from "@/db/db-client"
 
 afterAll(() => db.destroy())
 
-// TODO: set up migrations such
-test('database client connect correctly', async () => {
-  const application = await db("application").where({ id: 250 }).first();
-  expect(application).not.toBe(null);
-});
+describe("db/db-client", () => {
+  test("database client connect correctly", async () => {
+    const application = await db("application").where({ id: 250 }).first()
+    expect(application).not.toBe(null)
+  })
+
+  test("select query injects schema", () => {
+    expect(db.select("id").from("user").toString()).toBe("select [id] from [sfa].[user]")
+  })
+
+  test("direct function usage injects schema", () => {
+    expect(db("user").limit(10).toString()).toBe("select top (10) * from [sfa].[user]")
+  })
+
+  test("from usage injects schema", () => {
+    expect(db.from("user").limit(10).toString()).toBe("select top (10) * from [sfa].[user]")
+  })
+
+  test("direct function usage with custom schema replaces schema", () => {
+    expect(db("user").withSchema("dbo").limit(10).toString()).toBe(
+      "select top (10) * from [dbo].[user]"
+    )
+  })
+
+  test("direct custom schema usage replaces schema", () => {
+    expect(db.withSchema("dbo").from("user").limit(10).toString()).toBe(
+      "select top (10) * from [dbo].[user]"
+    )
+  })
+
+  test("raw usage works correctly", () => {
+    expect(db.raw("select top (10) * from [dbo].[user]").toString()).toBe(
+      "select top (10) * from [dbo].[user]"
+    )
+  })
+
+  test("migrate attribute returns a migrator instace", () => {
+    expect(db.migrate).toHaveProperty("latest")
+  })
+})


### PR DESCRIPTION
Relates to https://github.com/icefoganalytics/student-financial-aid/issues/2
Fixes https://github.com/icefoganalytics/sfa-client/issues/26

# Context

As part of the "view submitted applications and their current status" project, this task covers returning the other funding data. Depending on how that goes I might add in other sections such as:

<details>
<summary>other-fields.json</summary>

```json
{
  "studentDependants": { "dependants": [] },
  "csfaAccomodation": {},
  "csfaIncome": { "incomes": [] },
  "csfaExpenses": { "expenses": [] },
  "parents": {},
  "parentDependants": {},
  "spouse": {},
  "documents": {}
}
```

</details>

# Data Format

```json
{
  "id": "some-application-id",
  "otherFunding": {},
}
```

# Testing Instructions

1. Boot the `sfa-client` repo via `API_PORT=3100 dev up`
2. Boot the `student-financial-aid` front- and back-ends.
3. Log in to the app at http://localhost:8080/
4. Go to http://localhost:3000/api/portal/students/1/applications/2198 and you will see the mostly blank other funding section.
5. Go to http://localhost:3000/api/portal/students/6650/applications/265 and you will see that otherFunding has "otherFundings" with a couple of purposes.