### PR TITLE
Enhancement: Add Student CSFA Accomodation Section to Student Application Endpoint Response

### DIFF
--- a/src/api/models/accommodation_type.ts
+++ b/src/api/models/accommodation_type.ts
@@ -1,0 +1,30 @@
+// TODO: question whether this should be in the database at all.
+// And if so, why is it its own table?
+enum AccommodationTypes {
+  LIVING_AT_PARENTS = 1,
+  LIVING_ON_OWN = 2,
+  BOTH = 3,
+}
+
+export default class AccommodationType {
+  id: number
+  description: string
+  isActive: boolean
+
+  constructor({
+    id,
+    description,
+    isActive,
+  }: {
+    id: number
+    description: string
+    isActive: boolean
+  }) {
+    this.id = id
+    this.description = description
+    this.isActive = isActive
+  }
+
+  // not in database
+  static readonly Types = AccommodationTypes
+}

--- a/src/api/serializers/applications/student-applications-serializer.ts
+++ b/src/api/serializers/applications/student-applications-serializer.ts
@@ -67,6 +67,7 @@ export default class StudentApplicationsSerializer {
       studentDependants: this.#studentDependantsSection(
         this.#application.student?.dependents || ([] as Dependent[])
       ),
+      csfaAccommodation: this.#csfaAccomodationSection(this.#application),
     }
   }
 
@@ -337,6 +338,41 @@ export default class StudentApplicationsSerializer {
     return {
       hasDependants: !isEmpty(serializedDependents),
       dependants: serializedDependents,
+    }
+  }
+
+  #csfaAccomodationSection(application: Application) {
+    const accommodations = []
+    if (!isNil(application.prestudyAccomCode)) {
+      accommodations.push({
+        living: application.prestudyAccomCode,
+        ownHome: application.prestudyOwnHome,
+        rentToParents: application.prestudyBoardAmount,
+        cityId: application.prestudyCityId,
+        city: application.prestudyCityId,
+        provinceId: application.prestudyProvinceId,
+        province: application.prestudyProvinceId,
+        busService: application.prestudyBus,
+        distanceFromSchool: application.prestudyDistance, // NOTE: spelling updated from distinct_from_school used in front-end
+      })
+    }
+
+    if (!isNil(application.studyAccomCode)) {
+      accommodations.push({
+        living: application.studyAccomCode,
+        ownHome: application.studyOwnHome,
+        rentToParents: application.studyBoardAmount,
+        cityId: application.studyCityId,
+        city: application.studyCityId,
+        provinceId: application.studyProvinceId,
+        province: application.studyProvinceId,
+        busService: application.studyBus,
+        distanceFromSchool: application.studyDistance, // NOTE: spelling updated from distinct_from_school used in front-end
+      })
+    }
+
+    return {
+      accommodations // NOTE: spelling updated from accomodations (one m) used in front-end
     }
   }
 }


### PR DESCRIPTION
Relates to https://github.com/icefoganalytics/student-financial-aid/issues/2
Fixes https://github.com/icefoganalytics/sfa-client/issues/30

# Context

As part of the "view submitted applications and their current status" project, this task covers returning the student CSFA accommodations data.

# Implementation

Decide to standardize spelling in back end, because I don't want to propagate the typos. I'd rather require the front-end be fixed to match.

# Data Format

```js
{
  "id": "some-application-id",
  "csfaAccommodation": {
    "accommodations": [
      {
        ...
      }
   ],
  },
}
```

# Testing Instructions

1. Boot the `sfa-client` repo via `API_PORT=3100 dev up`
2. Boot the `student-financial-aid` front- and back-ends.
3. Log in to the app at http://localhost:8080/
4. Go to http://localhost:3000/api/portal/students/1/applications/2198 and you will see an example of some accommodations.